### PR TITLE
Collapse travis matrix into serial tests

### DIFF
--- a/cleanup-passes.js
+++ b/cleanup-passes.js
@@ -47,6 +47,7 @@ function cleanup(element) {
       .then(cleanupBower.bind(null, element))
       .then(generateReadme.bind(null, element))
       .then(generateContributionGuide.bind(null, element))
+      .then(cleanupTravisConfig.bind(null, element))
       ;
 }
 
@@ -283,6 +284,33 @@ If you edit this file, your changes will get overridden :)
   return element.repo.createCommitOnHead(
         ['CONTRIBUTING.md'], getSignature(), getSignature(),
         commitMessage);
+}
+
+function cleanupTravisConfig(element) {
+  const yaml = require('js-yaml');
+  const travisConfigPath = path.join(element.dir, '.travis.yml');
+
+  if (!existsSync(travisConfigPath)) {
+    return Promise.resolve();
+  }
+
+  const travisConfigBlob = fs.readFileSync(travisConfigPath, 'utf-8');
+
+  let travis = yaml.safeLoad(travisConfigBlob);
+
+  // update travis config
+
+  const updatedTravisConfigBlob = yaml.safeDump(travis);
+
+  if (travisConfigBlob !== updatedTravisConfigBlob) {
+    fs.writeFileSync(travisConfigPath, updatedTravisConfigBlob, 'utf-8');
+    element.dirty = true;
+    const commitMessage = '[skip ci] Update travis config';
+    return element.repo.createCommitOnHead(
+      ['.travis.yml'], getSignature(), getSignature(),
+      commitMessage
+    );
+  }
 }
 
 // Generates a git commit signature for the bot.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "github": "^0.2.0",
     "github-cache": "^1.1.0",
     "hydrolysis": "^1.19.3",
+    "js-yaml": "^3.4.3",
     "nodegit": "^0.5.0",
     "pad": "^1.0.0",
     "progress": "^1.1.8",

--- a/tedium.js
+++ b/tedium.js
@@ -58,7 +58,7 @@ const cli = cliArgs([
       throw new Error(`invalid max changes, expected an integer: ${x}`);
     },
     alias: "c",
-    description: "The maximum number of repos to push. Defualt: 0",
+    description: "The maximum number of repos to push. Default: 0",
     defaultValue: 0
   },
 ]);


### PR DESCRIPTION
- Test time is mostly governed by vm startup time, multiple vms seems not
  helpful
- Node 4 LTS for element testing, npm seems faster
- Fix firefox travis addon to use '42.0' until travis fixes the 'latest' flag
  - travis-ci/travis-ci#5082
- preserve 'scripts' content from each matrix column
- Fix spelling of 'default' in tedium binary
