### PR TITLE
Have `repo` arg always return an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "github-cache": "^1.1.0",
     "hydrolysis": "^1.19.3",
     "js-yaml": "^3.4.3",
-    "nodegit": "^0.5.0",
+    "nodegit": "^0.6.0",
     "pad": "^1.0.0",
     "progress": "^1.1.8",
     "promisify-node": "^0.2.1",

--- a/tedium.ts
+++ b/tedium.ts
@@ -73,6 +73,7 @@ const cli = cliArgs([
       }
       return {user: parts[0], repo: parts[1]};
     },
+    defaultValue: [],
     multiple: true,
     alias: 'r',
     description:


### PR DESCRIPTION
Use nodegit 0.6.0, for better Node 5 support
