### PR TITLE
Sort behavior names before writing README

### DIFF
--- a/cleanup-passes/readme.ts
+++ b/cleanup-passes/readme.ts
@@ -120,7 +120,8 @@ Edit this file, and the bot will squash your changes :)
 ${analyzedElement.desc}
 `;
   }
-  for (const name in behaviorsByName) {
+
+  for (const name of Object.keys(behaviorsByName).sort()) {
     const behavior = behaviorsByName[name];
 
     if (!behavior.desc || behavior.desc.trim() === '') {

--- a/cleanup-passes/readme.ts
+++ b/cleanup-passes/readme.ts
@@ -120,8 +120,21 @@ Edit this file, and the bot will squash your changes :)
 ${analyzedElement.desc}
 `;
   }
-
-  for (const name of Object.keys(behaviorsByName).sort()) {
+  // If this repo is named after a behavior, what would that behavior be named?
+  // This turns e.g. iron-a11y-keys-behavior into
+  // Polymer.IronA11yKeysBehavior
+  const canonicalBehaviorName =
+      'Polymer.' + wordsWithDashesToCamelCase(element.ghRepo.name);
+  const behaviorNames = Object.keys(behaviorsByName).sort((l, r) => {
+    if (l === canonicalBehaviorName) {
+      return -1;
+    }
+    if (r === canonicalBehaviorName) {
+      return 1;
+    }
+    return l.localeCompare(r);
+  });
+  for (const name of behaviorNames) {
     const behavior = behaviorsByName[name];
 
     if (!behavior.desc || behavior.desc.trim() === '') {
@@ -146,6 +159,12 @@ ${behavior.desc}
     await makeCommit(
         element, ['README.md'], '[skip ci] Autogenerate README file.');
   }
+}
+
+function wordsWithDashesToCamelCase(wordsWithDashes:string):string {
+  return wordsWithDashes.split('-').map((word) => {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+  }).join('');
 }
 
 export let cleanupPasses = [generateReadme];


### PR DESCRIPTION
Previously we were just sorting the tag names of elements.

We need to sort so that we don't thrash and repeatedly rearrange files
for no reason.
