### PR TITLE
Track more metadata about cleanup passes.

### DIFF
--- a/cleanup-pass.ts
+++ b/cleanup-pass.ts
@@ -1,0 +1,45 @@
+import {ElementRepo} from './element-repo';
+
+const passes: CleanupPass[] = [];
+
+/**
+ * Add a cleanup pass to the global registry.
+ */
+export function register(p: CleanupPass) {
+  passes.push(p);
+}
+
+/**
+ * Return all cleanup passes that have been registered so far.
+ */
+export function getPasses() {
+  return passes.slice();
+}
+
+export interface CleanupPass {
+  /**
+   * Name of the cleanup pass. Also used as an identifier in the config.json.
+   */
+  name: string;
+
+  /**
+   * Is this cleanup pass stable / reliable enough to run by default?
+   */
+  runsByDefault: boolean;
+
+  /**
+   * The implementation function for the cleanup pass.
+   */
+  pass(element: ElementRepo): Promise<void>;
+}
+
+/**
+ * Type of the "passes" section of the config.json.
+ *
+ * See tedium.ts for the full type of config.json.
+ */
+export interface CleanupConfig {
+  [passName: string]: {
+    blacklist?: string[];
+  }
+}

--- a/cleanup-passes/bower.ts
+++ b/cleanup-passes/bower.ts
@@ -16,6 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {register} from '../cleanup-pass';
 import {ElementRepo} from '../element-repo.ts';
 import {existsSync, makeCommit} from './util';
 
@@ -85,4 +87,8 @@ async function cleanupBower(element: ElementRepo): Promise<void> {
   }
 }
 
-export let cleanupPasses = [cleanupBower];
+register({
+  name: 'bower',
+  pass: cleanupBower,
+  runsByDefault: true,
+});

--- a/cleanup-passes/contribution-guide.ts
+++ b/cleanup-passes/contribution-guide.ts
@@ -16,6 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {register} from '../cleanup-pass';
 import {ElementRepo} from '../element-repo.ts';
 import {existsSync, makeCommit} from './util';
 
@@ -60,4 +62,8 @@ If you edit this file, your changes will get overridden :)
   await makeCommit(element, ['CONTRIBUTING.md'], commitMessage);
 }
 
-export let cleanupPasses = [generateContributionGuide];
+register({
+  name: 'contribution guide',
+  pass: generateContributionGuide,
+  runsByDefault: true,
+});

--- a/cleanup-passes/contribution-guide.ts
+++ b/cleanup-passes/contribution-guide.ts
@@ -63,7 +63,7 @@ If you edit this file, your changes will get overridden :)
 }
 
 register({
-  name: 'contribution guide',
+  name: 'contribution-guide',
   pass: generateContributionGuide,
   runsByDefault: true,
 });

--- a/cleanup-passes/readme.ts
+++ b/cleanup-passes/readme.ts
@@ -16,6 +16,8 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {register} from '../cleanup-pass';
 import {ElementRepo} from '../element-repo.ts';
 import {existsSync, makeCommit} from './util';
 
@@ -24,33 +26,6 @@ import {existsSync, makeCommit} from './util';
  * Generates README.md for the element, unless it's in the blacklist.
  */
 async function generateReadme(element: ElementRepo): Promise<void> {
-  const manualReadmeRepos = new Set([
-    'repos/molecules',
-    'repos/iron-elements',
-    'repos/paper-elements',
-    'repos/neon-elements',
-    'repos/gold-elements',
-    'repos/platinum-elements',
-    'repos/seed-element',
-    'repos/app-layout-templates',
-    'repos/polymer-starter-kit',
-    'repos/quick-element',
-    'repos/font-roboto',
-    'repos/iron-test-helpers',
-    'repos/font-roboto-local',
-
-    // Temporary:
-    // Blocked on https://github.com/Polymer/hydrolysis/issues/188
-    'repos/iron-iconset',
-    // Blocked on getting the order of elements more correct, and moving the
-    // extra documentation that's currently only in the README somewhere
-    // that tedium can access.
-    'repos/platinum-sw',
-    'repos/neon-animation',
-  ]);
-  if (manualReadmeRepos.has(element.dir)) {
-    return;
-  }
   const implementationFiles = new Set();
 
   const elementsByTagName = {};
@@ -167,4 +142,8 @@ function wordsWithDashesToCamelCase(wordsWithDashes:string):string {
   }).join('');
 }
 
-export let cleanupPasses = [generateReadme];
+register({
+  name: 'readme',
+  pass: generateReadme,
+  runsByDefault: true,
+});

--- a/cleanup-passes/register-all.ts
+++ b/cleanup-passes/register-all.ts
@@ -1,0 +1,5 @@
+import './bower';
+import './contribution-guide';
+import './readme';
+import './tests';
+import './travis';

--- a/cleanup-passes/tests.ts
+++ b/cleanup-passes/tests.ts
@@ -120,7 +120,7 @@ async function addShadowDomTests(element: ElementRepo): Promise<void> {
 }
 
 register({
-  name: 'add shadow dom tests',
+  name: 'add-shadow-dom-tests',
   pass: addShadowDomTests,
   // Mark this as true once we've merged all the PRs from this
   // sheet:

--- a/cleanup-passes/tests.ts
+++ b/cleanup-passes/tests.ts
@@ -20,6 +20,8 @@ import * as espree from 'espree';
 import * as estree_walker from 'estree-walker';
 import * as fs from 'fs';
 import * as path from 'path';
+
+import {register} from '../cleanup-pass';
 import {ElementRepo} from '../element-repo.ts';
 import {existsSync, makeCommit} from './util';
 
@@ -117,4 +119,11 @@ async function addShadowDomTests(element: ElementRepo): Promise<void> {
   }
 }
 
-export let cleanupPasses = [addShadowDomTests];
+register({
+  name: 'add shadow dom tests',
+  pass: addShadowDomTests,
+  // Mark this as true once we've merged all the PRs from this
+  // sheet:
+  // https://docs.google.com/spreadsheets/d/166pE8UwkJQwtUzirEv03kDYQmilKO0-ggZBrrzyDh9g/edit#gid=0
+  runsByDefault: false,
+});

--- a/cleanup-passes/travis.ts
+++ b/cleanup-passes/travis.ts
@@ -17,6 +17,8 @@
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as path from 'path';
+
+import {register} from '../cleanup-pass';
 import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 
@@ -151,4 +153,9 @@ async function cleanupTravisConfig(element: ElementRepo): Promise<void> {
   }
 }
 
-export let cleanupPasses = [cleanupTravisConfig];
+register({
+  name: 'cleanup travis',
+  pass: cleanupTravisConfig,
+  // Disabled until we've merged all of the polylint changes.
+  runsByDefault: false,
+});

--- a/cleanup-passes/travis.ts
+++ b/cleanup-passes/travis.ts
@@ -154,7 +154,7 @@ async function cleanupTravisConfig(element: ElementRepo): Promise<void> {
 }
 
 register({
-  name: 'cleanup travis',
+  name: 'travis',
   pass: cleanupTravisConfig,
   // Disabled until we've merged all of the polylint changes.
   runsByDefault: false,

--- a/cleanup-passes/util.ts
+++ b/cleanup-passes/util.ts
@@ -44,5 +44,3 @@ export async function makeCommit(
   await element.repo.createCommitOnHead(
       files, getSignature(), getSignature(), commitMessage);
 }
-
-export interface CleanupPass { (element: ElementRepo): Promise<void>; }

--- a/cleanup.ts
+++ b/cleanup.ts
@@ -14,16 +14,14 @@
 
 'use strict';
 
-import {cleanupPasses as bowerPasses} from './cleanup-passes/bower';
-import {cleanupPasses as readmePasses} from './cleanup-passes/readme';
-import {cleanupPasses as testPasses} from './cleanup-passes/tests';
-import {cleanupPasses as travisPasses} from './cleanup-passes/travis';
-import {CleanupPass} from './cleanup-passes/util';
+import './cleanup-passes/bower';
+import './cleanup-passes/contribution-guide';
+import './cleanup-passes/readme';
+import './cleanup-passes/tests';
+import './cleanup-passes/travis';
+
 import {ElementRepo} from './element-repo';
-
-
-const cleanupPasses: CleanupPass[] =
-    [].concat(bowerPasses, readmePasses, testPasses, travisPasses);
+import {getPasses, CleanupConfig} from './cleanup-pass';
 
 /**
  * The meat of the implementation. If any cleanup step makes any changes it
@@ -35,8 +33,17 @@ const cleanupPasses: CleanupPass[] =
  *
  * To add a cleanup step, just add it to the array of passes above.
  */
-export async function cleanup(element: ElementRepo): Promise<void> {
-  for (const step of cleanupPasses) {
-    await step(element);
+export async function cleanup(
+    element: ElementRepo, config: CleanupConfig): Promise<void> {
+  for (const step of getPasses()) {
+    const stepConfig = config[step.name] || {};
+    if (!step.runsByDefault) {
+      continue;
+    }
+    if (stepConfig.blacklist &&
+        stepConfig.blacklist.indexOf(element.dir) !== -1) {
+      continue;
+    }
+    await step.pass(element);
   }
 }

--- a/cleanup.ts
+++ b/cleanup.ts
@@ -14,12 +14,7 @@
 
 'use strict';
 
-import './cleanup-passes/bower';
-import './cleanup-passes/contribution-guide';
-import './cleanup-passes/readme';
-import './cleanup-passes/tests';
-import './cleanup-passes/travis';
-
+import './cleanup-passes/register-all';
 import {ElementRepo} from './element-repo';
 import {getPasses, CleanupConfig} from './cleanup-pass';
 
@@ -34,12 +29,15 @@ import {getPasses, CleanupConfig} from './cleanup-pass';
  * To add a cleanup step, just add it to the array of passes above.
  */
 export async function cleanup(
-    element: ElementRepo, config: CleanupConfig): Promise<void> {
-  for (const step of getPasses()) {
-    const stepConfig = config[step.name] || {};
-    if (!step.runsByDefault) {
-      continue;
+    element: ElementRepo, config: CleanupConfig, passesToRun?: string[]) {
+  const passes = getPasses().filter(p => {
+    if (passesToRun == null) {
+      return p.runsByDefault;
     }
+    return passesToRun.indexOf(p.name) >= 0;
+  });
+  for (const step of passes) {
+    const stepConfig = config[step.name] || {};
     if (stepConfig.blacklist &&
         stepConfig.blacklist.indexOf(element.dir) !== -1) {
       continue;

--- a/config.json
+++ b/config.json
@@ -1,0 +1,30 @@
+{
+  "passes": {
+    "readme": {
+      "blacklist": [
+        "repos/molecules",
+        "repos/iron-elements",
+        "repos/paper-elements",
+        "repos/neon-elements",
+        "repos/gold-elements",
+        "repos/platinum-elements",
+        "repos/seed-element",
+        "repos/app-layout-templates",
+        "repos/polymer-starter-kit",
+        "repos/quick-element",
+        "repos/font-roboto",
+        "repos/iron-test-helpers",
+        "repos/font-roboto-local",
+
+        // Temporary:
+        // Blocked on https://github.com/Polymer/hydrolysis/issues/188
+        "repos/iron-iconset",
+        // Blocked on getting the order of elements more correct, and moving the
+        // extra documentation that's currently only in the README somewhere
+        // that tedium can access.
+        "repos/platinum-sw",
+        "repos/neon-animation"
+      ]
+    }
+  }
+}

--- a/config.json
+++ b/config.json
@@ -1,3 +1,6 @@
+// (This file is JSON with the extension that JS comments are allowed.)
+
+// A default config for Polymer team's use.
 {
   "passes": {
     "readme": {

--- a/custom_typings/strip-json-comments.d.ts
+++ b/custom_typings/strip-json-comments.d.ts
@@ -1,0 +1,5 @@
+declare module 'strip-json-comments' {
+  function stripJsonComments(jsonStr:string):string;
+  module stripJsonComments {}
+  export = stripJsonComments;
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "pad": "^1.0.0",
     "progress": "^1.1.8",
     "promisify-node": "^0.3.0",
-    "rimraf": "^2.4.3"
+    "rimraf": "^2.4.3",
+    "strip-json-comments": "^2.0.0"
   },
   "devDependencies": {
     "tsd": "^0.6.5",

--- a/tedium.ts
+++ b/tedium.ts
@@ -41,12 +41,13 @@ import * as promisify from 'promisify-node';
 import * as rimraf from 'rimraf';
 import * as stripJsonComments from 'strip-json-comments';
 
+import './cleanup-passes/register-all';
 import {cleanup} from './cleanup';
-import {CleanupConfig} from './cleanup-pass';
+import {CleanupConfig, getPasses} from './cleanup-pass';
 import {existsSync} from './cleanup-passes/util';
 import {ElementRepo, PushStatus} from './element-repo';
 
-
+const passNames = getPasses().map(p => p.name);
 const cli = cliArgs([
   {name: "help", type: Boolean, alias: "h", description: "Print usage."},
   {
@@ -82,6 +83,18 @@ const cli = cliArgs([
     description:
         'Explicit repos to process. Specifying explicit repos will disable running on the implicit set of repos for the user.'
   },
+  {
+    name: 'pass',
+    multiple: true,
+    type: (passName) => {
+      if (passNames.indexOf(passName) < 0) {
+        throw new Error(`Unknown cleanup pass name "${passName}"`);
+      }
+      return passName;
+    },
+    defaultValue: [],
+    description: "Cleanup passes to run. If this flag is used then only the given passes will run, and they will run even if they're disabled by default."
+  }
 ]);
 interface UserRepo {
   user: string;
@@ -91,6 +104,7 @@ interface Options {
   help: boolean;
   max_changes: number;
   repo: UserRepo[];
+  pass: string[];
 }
 const opts: Options = cli.parse();
 
@@ -493,14 +507,19 @@ async function _main(elements: ElementRepo[]) {
   const cleanupProgress =
       standardProgressBar('Applying transforms...', elements.length);
   for (const element of elements) {
+    let passesToRun: string[] = null;
+    if (opts.pass.length > 0) {
+      passesToRun = opts.pass;
+    }
     if (excludes.has(element.dir)) {
       cleanupProgress.tick();
       continue;
     }
+    
     await Promise.resolve()
         .then(checkoutNewBranch.bind(null, element.repo, branchName))
         .then(rateLimit.bind(null, 0))
-        .then(cleanup.bind(null, element, config.passes || {}))
+        .then(cleanup.bind(null, element, config.passes || {}, passesToRun))
         .then(pushChanges.bind(null, element, branchName, user.login))
         .catch((err) => {
           throw new Error(

--- a/tedium.ts
+++ b/tedium.ts
@@ -93,7 +93,7 @@ const cli = cliArgs([
       return passName;
     },
     defaultValue: [],
-    description: "Cleanup passes to run. If this flag is used then only the given passes will run, and they will run even if they're disabled by default."
+    description: `Cleanup passes to run. If this flag is used then only the given passes will run, and they will run even if they're disabled by default. Pass names: ${passNames.join(', ')}`
   }
 ]);
 interface UserRepo {

--- a/tedium.ts
+++ b/tedium.ts
@@ -515,16 +515,16 @@ async function _main(elements: ElementRepo[]) {
       cleanupProgress.tick();
       continue;
     }
-    
-    await Promise.resolve()
-        .then(checkoutNewBranch.bind(null, element.repo, branchName))
-        .then(rateLimit.bind(null, 0))
-        .then(cleanup.bind(null, element, config.passes || {}, passesToRun))
-        .then(pushChanges.bind(null, element, branchName, user.login))
-        .catch((err) => {
-          throw new Error(
-              `Error updating ${element.dir}:\n${err.stack || err}`);
-        });
+
+    try {
+      await checkoutNewBranch(element.repo, branchName);
+      await rateLimit(0);
+      await cleanup(element, config.passes || {}, passesToRun);
+      await pushChanges(element, branchName, user.login);
+    } catch (err) {
+      throw new Error(
+          `Error updating ${element.dir}:\n${err.stack || err}`);
+    }
     cleanupProgress.tick();
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
         "cleanup-passes/bower.ts",
         "cleanup-passes/contribution-guide.ts",
         "cleanup-passes/readme.ts",
+        "cleanup-passes/register-all.ts",
         "cleanup-passes/tests.ts",
         "cleanup-passes/travis.ts",
         "cleanup-passes/util.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
         "declaration": false,
         "noImplicitAny": true,
         "removeComments": false,
-        "noLib": false,
         "preserveConstEnums": true,
         "suppressImplicitAnyIndexErrors": true
     },
@@ -19,6 +18,7 @@
         "custom_typings/*.d.ts"
     ],
     "files": [
+        "cleanup-pass.ts",
         "cleanup-passes/bower.ts",
         "cleanup-passes/contribution-guide.ts",
         "cleanup-passes/readme.ts",
@@ -37,6 +37,7 @@
         "custom_typings/nodegit.d.ts",
         "custom_typings/pad.d.ts",
         "custom_typings/promisify-node.d.ts",
+        "custom_typings/strip-json-comments.d.ts",
         "element-repo.ts",
         "tedium.ts",
         "typings/js-yaml/js-yaml.d.ts",


### PR DESCRIPTION
Also moves the blacklist into a config file. My thinking here is
that we're going to want to expand this config file in the future
such that all of the PolymerElements-specific material will live
in the config file, making it possible for other folks to use
tedium to do README generation, etc.
