### PR TITLE
Remove github-cache

### DIFF
--- a/custom_typings/github.d.ts
+++ b/custom_typings/github.d.ts
@@ -1,9 +1,7 @@
-declare module 'github-cache' {
+declare module 'github' {
   interface Options {
     version: string;
     protocol: string;
-    cachedb: string;
-    validateCache: boolean;
   }
   interface CreatePullRequestOpts {
     user: string;

--- a/element-repo.ts
+++ b/element-repo.ts
@@ -13,7 +13,7 @@
  */
 'use strict';
 
-import {Repo} from 'github-cache';
+import {Repo} from 'github';
 import {Analyzer} from 'hydrolysis';
 import * as nodegit from 'nodegit';
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "espree": "^2.2.5",
     "estree-walker": "^0.2.0",
     "github": "^0.2.0",
-    "github-cache": "^1.1.0",
     "hydrolysis": "^1.19.3",
     "js-yaml": "^3.4.3",
     "nodegit": "^0.7.0",

--- a/tedium.ts
+++ b/tedium.ts
@@ -31,7 +31,7 @@
 
 import * as cliArgs from 'command-line-args';
 import * as fs from 'fs';
-import * as GitHub from 'github-cache';
+import * as GitHub from 'github';
 import * as hydrolysis from 'hydrolysis';
 import * as nodegit from 'nodegit';
 import * as pad from 'pad';
@@ -342,8 +342,6 @@ function connectToGithub() {
   const github = new GitHub({
     version: "3.0.0",
     protocol: "https",
-    cachedb: './.github-cachedb',
-    validateCache: true
   });
 
   github.authenticate({type: 'oauth', token: GITHUB_TOKEN});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,7 @@
         "custom_typings/escodegen.d.ts",
         "custom_typings/espree.d.ts",
         "custom_typings/estree-walker.d.ts",
-        "custom_typings/github-cache.d.ts",
+        "custom_typings/github.d.ts",
         "custom_typings/hydrolysis.d.ts",
         "custom_typings/main.d.ts",
         "custom_typings/nodegit.d.ts",


### PR DESCRIPTION
It doesn't seem like tedium hits the cache very often, and this saves ~9mb of
install size and removes a post-install download of the leveldown bindings.
