### PR TITLE
Fix issue where issue templates never updated

### DIFF
--- a/cleanup-passes/issue-template.ts
+++ b/cleanup-passes/issue-template.ts
@@ -67,21 +67,15 @@ async function addIssueTemplate(element: ElementRepo): Promise<void> {
     fs.mkdirSync(templateFolderPath);
   }
   const templatePath = path.join(element.dir, repoTemplatePath);
-  let templateContent = '';
-  let templateExisted = false;
-  if (existsSync(templatePath)) {
-    templateContent = fs.readFileSync(templatePath, 'utf8');
-    templateExisted = true;
-    if (templateContent === issueTemplate) {
-      return;
+  const templateExisted = existsSync(templatePath);
+  if (templateExisted) {
+    if (fs.readFileSync(templatePath, 'utf8') === issueTemplate) {
+      return;  // No changes to make.
     }
-  } else {
-    templateContent = issueTemplate;
   }
 
-  fs.writeFileSync(templatePath, templateContent, 'utf8');
+  fs.writeFileSync(templatePath, issueTemplate, 'utf8');
   const message = `[ci skip] ${templateExisted ? 'Update' : 'Add'} Issue Template`;
-  console.log(templatePath);
   await makeCommit(element, [repoTemplatePath], message);
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,14 +11,18 @@
         "suppressImplicitAnyIndexErrors": true
     },
     "filesGlob": [
-        "**/*.ts",
-        "**/*.tsx",
+        "*.ts",
+        "cleanup-passes/*.ts",
         "!node_modules/**",
         "typings/main.d.ts",
         "custom_typings/*.d.ts"
     ],
     "files": [
         "cleanup-pass.ts",
+        "cleanup.ts",
+        "element-repo.ts",
+        "markdown-lang-autodetect.ts",
+        "tedium.ts",
         "cleanup-passes/bower.ts",
         "cleanup-passes/contribution-guide.ts",
         "cleanup-passes/issue-template.ts",
@@ -29,7 +33,7 @@
         "cleanup-passes/tests.ts",
         "cleanup-passes/travis.ts",
         "cleanup-passes/util.ts",
-        "cleanup.ts",
+        "typings/main.d.ts",
         "custom_typings/command-line-args.d.ts",
         "custom_typings/dom5.d.ts",
         "custom_typings/escodegen.d.ts",
@@ -43,11 +47,7 @@
         "custom_typings/nodegit.d.ts",
         "custom_typings/pad.d.ts",
         "custom_typings/promisify-node.d.ts",
-        "custom_typings/strip-json-comments.d.ts",
-        "element-repo.ts",
-        "markdown-lang-autodetect.ts",
-        "tedium.ts",
-        "typings/main.d.ts"
+        "custom_typings/strip-json-comments.d.ts"
     ],
     "atom": {
         "rewriteTsconfig": true


### PR DESCRIPTION
There's a small logic bug in `issue-template.ts` such that if the file exists then it is never updated, and if changes are needed then blank commits are generated. e.g. https://github.com/PolymerElements/iron-location/commits/master

The bug is with assigning `templateContent` to the current text of the file, then writing `templateContent`. I think the intended behavior is to always write `issueTemplate` out. This does appear to fix the bug.
