### PR TITLE
Fix imports

### DIFF
--- a/cleanup-passes/bower.ts
+++ b/cleanup-passes/bower.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 
 /**

--- a/cleanup-passes/contribution-guide.ts
+++ b/cleanup-passes/contribution-guide.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit, getJsBinLink} from './util';
 
 /**

--- a/cleanup-passes/license-header.ts
+++ b/cleanup-passes/license-header.ts
@@ -22,7 +22,7 @@ import * as promisify from 'promisify-node';
 import * as glob from 'glob';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 
 const polymerHeader =

--- a/cleanup-passes/package-json.ts
+++ b/cleanup-passes/package-json.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 
 const dependencyMap = {

--- a/cleanup-passes/readme.ts
+++ b/cleanup-passes/readme.ts
@@ -18,7 +18,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 import {injectAutodetectedLanguage} from '../markdown-lang-autodetect';
 import {Element, Behavior} from 'hydrolysis';

--- a/cleanup-passes/tests.ts
+++ b/cleanup-passes/tests.ts
@@ -22,7 +22,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import {register} from '../cleanup-pass';
-import {ElementRepo} from '../element-repo.ts';
+import {ElementRepo} from '../element-repo';
 import {existsSync, makeCommit} from './util';
 
 


### PR DESCRIPTION
This fixes the error T2691 in various files:
cleanup-passes/bower.ts(21,27): error TS2691: An import path cannot end with a '.ts' extension. Consider importing '../element-repo' instead.