### PR TITLE
Update nodegit to 0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "hydrolysis": "^1.19.3",
     "js-yaml": "^3.4.3",
     "marked": "^0.3.5",
-    "nodegit": "^0.11.3",
+    "nodegit": "^0.16.0",
     "pad": "^1.0.0",
     "progress": "^1.1.8",
     "promisify-node": "^0.3.0",


### PR DESCRIPTION
This fixes compilation on Fedora 24/Node v7.1.0/gcc 6.2.1