### PR TITLE
Update: travis config

### DIFF
--- a/cleanup-passes/polymer-json.ts
+++ b/cleanup-passes/polymer-json.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as semver from 'semver';
+import {ProjectOptions, LintOptions} from 'polymer-project-config';
+
+import {register} from '../cleanup-pass';
+import {ElementRepo} from '../element-repo';
+import {existsSync, makeCommit, writeToConfig} from './util';
+
+async function cleanupPolymer(element: ElementRepo): Promise<void> {
+  const bowerPath = path.join(element.dir, 'bower.json');
+  if (!existsSync(bowerPath)) {
+    return;  // No Bower file, skip generating polymer.json
+  }
+  // Read bower.json for Polymer version to better set Polymer lint rules
+  const bowerConfig: any = JSON.parse(fs.readFileSync(bowerPath, 'utf8'));
+
+  if (!bowerConfig || !bowerConfig.dependencies ||
+      bowerConfig.dependencies.length === 0 ||
+      !bowerConfig.dependencies.polymer) {
+    return;  // Not using Polymer, skip generating polymer.json
+  }
+
+  const polymerDefault: ProjectOptions = {lint: {rules: []}};
+
+  let polymerConfig: ProjectOptions = polymerDefault;
+  const polymerPath = path.join(element.dir, 'polymer.json');
+  const configExists = existsSync(polymerPath);
+  if (configExists) {
+    polymerConfig =
+        JSON.parse(fs.readFileSync(polymerPath, 'utf8')) || polymerDefault;
+  }
+
+  // Skip if lint rule(s) exist
+  if (polymerConfig.lint && polymerConfig.lint.rules &&
+      polymerConfig.lint.rules.length > 0) {
+    return;
+  } else {
+    // Default lint property if it doesn't exist
+    polymerConfig.lint = polymerDefault.lint as LintOptions;
+  }
+
+  // Update the lint property based on the Polymer version
+  const polymerVersion = bowerConfig.dependencies.polymer.split('#')[1];
+  if (semver.satisfies('2.0', polymerVersion)) {
+    if (semver.satisfies('1.9', polymerVersion)) {
+      polymerConfig.lint.rules.push('polymer-2-hybrid');
+    } else {
+      polymerConfig.lint.rules.push('polymer-2');
+    }
+  } else {
+    polymerConfig.lint.rules.push('polymer-1');
+  }
+
+  // Write the Polymer config object out to the given path
+  writeToConfig(polymerPath, polymerConfig);
+  let commitMsg: string = 'Add basic polymer config';
+  if (configExists) {
+    commitMsg = 'Add polymer lint property';
+  }
+  await makeCommit(element, ['polymer.json'], commitMsg);
+}
+
+register({name: 'polymer', pass: cleanupPolymer, runsByDefault: true});

--- a/cleanup-passes/polymer-json.ts
+++ b/cleanup-passes/polymer-json.ts
@@ -77,4 +77,4 @@ async function cleanupPolymer(element: ElementRepo): Promise<void> {
   await makeCommit(element, ['polymer.json'], commitMsg);
 }
 
-register({name: 'polymer', pass: cleanupPolymer, runsByDefault: true});
+register({name: 'polymer-json', pass: cleanupPolymer, runsByDefault: true});

--- a/cleanup-passes/util.ts
+++ b/cleanup-passes/util.ts
@@ -64,3 +64,24 @@ export function getJsBinLink(element: ElementRepo): string {
   }
   return jsbin;
 }
+
+export function writeToConfig(path: string, config: Object): void {
+  fs.writeFileSync(path, JSON.stringify(config, null, 2) + '\n', 'utf8');
+}
+
+// From
+// https://stackoverflow.com/questions/3115982/how-to-check-if-two-arrays-are-equal-with-javascript/16436975#16436975
+export function arraysEqual(a: String[], b: String[]): Boolean {
+  if (a === b)
+    return true;
+  if (a == null || b == null)
+    return false;
+  if (a.length != b.length)
+    return false;
+
+  for (let i = 0; i < a.length; ++i) {
+    if (a[i] !== b[i])
+      return false;
+  }
+  return true;
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@types/marked": "0.0.27",
     "@types/node": "^4.2.23",
     "@types/progress": "^1.1.27",
+    "@types/semver": "^5.4.0",
     "command-line-args": "^2.0.4",
     "del": "^3.0.0",
     "dom5": "^1.3.1",
@@ -47,8 +48,10 @@
     "marked": "^0.3.5",
     "nodegit": "^0.16.0",
     "pad": "^1.0.0",
+    "polymer-project-config": "^3.6.0",
     "progress": "^1.1.8",
     "promisify-node": "^0.3.0",
+    "semver": "^5.4.1",
     "source-map-support": "^0.4.11",
     "strip-json-comments": "^2.0.0"
   },


### PR DESCRIPTION
@azakus PTAL Second attempt at using TypeScript, open to feedback on ways to improve.

Fixes #57

- Moved `writeToBower` to a more generic `writeToConfig` for use in polymer.json as well.
- Added a `polymer-json.ts` that reads the `bower.json` for `polymer` dependency and constructs the `lint` property based on the version specified. Leaves existing lint rules alone. This is necessary for the `polymer lint` in the `.travis.yml`
- Updated `.travis.yml` to:
    - Run `polymer lint` in `before_script`
    - Override `install` to install the global tools(`polymer-cli`, `bower`, and `web-component-tester`) and install variants using `polymer install --variants`
    - Update `nodejs` version to `stable` which should be the latest LTS
    - Switch to containerized builds, using `sudo: false`
    - Use the Travis shorthand for Chrome install `chrome: stable`
    - Added `node_module` caching (Fixes #42)
    - Removed old tools necessary for building Chrome
    - Use `polymer test` to test all variants and browser instead of manual specifying of each.
        - Wasn't sure how to ensure that each repo is:
            - using `polymer test` without options `-l`
            - not using `wct`
            - using `polymer test -s` for commits
            - not messed up by these changes


Not entirely sure how to test this to make sure I didn't botch everything lol :sweat_smile: 

/cc @notwaldorf @rictic 