### PR TITLE
Fix parsing with empty travis file

### DIFF
--- a/cleanup-passes/travis.ts
+++ b/cleanup-passes/travis.ts
@@ -64,7 +64,7 @@ async function cleanupTravisConfig(element: ElementRepo): Promise<void> {
 
   const travisConfigBlob = fs.readFileSync(travisConfigPath, 'utf8');
 
-  let travis: TravisConfig = yaml.safeLoad(travisConfigBlob);
+  let travis: TravisConfig = yaml.safeLoad(travisConfigBlob) || {};
 
   const tools = ['polymer-cli'];
 


### PR DESCRIPTION
`app-media` had an empty Travis file (https://github.com/PolymerElements/app-media/blob/master/.travis.yml) which was breaking the bot. Adding an or for an object made sure the bot continued and generated the correct file.