### PR TITLE
Simplify tedium operation and make more conservative.

### DIFF
--- a/cleanup-pass.ts
+++ b/cleanup-pass.ts
@@ -23,11 +23,6 @@ export interface CleanupPass {
   name: string;
 
   /**
-   * Is this cleanup pass stable / reliable enough to run by default?
-   */
-  runsByDefault: boolean;
-
-  /**
    * The implementation function for the cleanup pass.
    */
   pass(element: ElementRepo): Promise<void>;

--- a/cleanup-passes/bower.ts
+++ b/cleanup-passes/bower.ts
@@ -78,8 +78,4 @@ async function cleanupBower(element: ElementRepo): Promise<void> {
   }
 };
 
-register({
-  name: 'bower',
-  pass: cleanupBower,
-  runsByDefault: true,
-});
+register({name: 'bower', pass: cleanupBower});

--- a/cleanup-passes/contribution-guide.ts
+++ b/cleanup-passes/contribution-guide.ts
@@ -76,8 +76,4 @@ ${contributionGuideContents}`;
   await makeCommit(element, ['CONTRIBUTING.md'], commitMessage);
 }
 
-register({
-  name: 'contribution-guide',
-  pass: generateContributionGuide,
-  runsByDefault: true,
-});
+register({name: 'contribution-guide', pass: generateContributionGuide});

--- a/cleanup-passes/issue-template.ts
+++ b/cleanup-passes/issue-template.ts
@@ -80,4 +80,4 @@ async function addIssueTemplate(element: ElementRepo): Promise<void> {
   await makeCommit(element, [repoTemplatePath], message);
 }
 
-register({name: 'issue-template', pass: addIssueTemplate, runsByDefault: true})
+register({name: 'issue-template', pass: addIssueTemplate})

--- a/cleanup-passes/license-header.ts
+++ b/cleanup-passes/license-header.ts
@@ -146,4 +146,4 @@ async function addLicenseHeader(element: ElementRepo): Promise<void> {
   }
 }
 
-register({name: 'license', pass: addLicenseHeader, runsByDefault: true});
+register({name: 'license', pass: addLicenseHeader});

--- a/cleanup-passes/package-json.ts
+++ b/cleanup-passes/package-json.ts
@@ -78,8 +78,4 @@ async function generatePackageJson(element: ElementRepo): Promise<void> {
       'Generate minimal package.json from bower.json');
 }
 
-register({
-  name: 'package-json',
-  pass: generatePackageJson,
-  runsByDefault: false,
-});
+register({name: 'package-json', pass: generatePackageJson});

--- a/cleanup-passes/polymer-json.ts
+++ b/cleanup-passes/polymer-json.ts
@@ -77,4 +77,4 @@ async function cleanupPolymer(element: ElementRepo): Promise<void> {
   await makeCommit(element, ['polymer.json'], commitMsg);
 }
 
-register({name: 'polymer-json', pass: cleanupPolymer, runsByDefault: true});
+register({name: 'polymer-json', pass: cleanupPolymer});

--- a/cleanup-passes/readme.ts
+++ b/cleanup-passes/readme.ts
@@ -173,8 +173,4 @@ function wordsWithDashesToCamelCase(wordsWithDashes: string): string {
       .join('');
 }
 
-register({
-  name: 'readme',
-  pass: generateReadme,
-  runsByDefault: true,
-});
+register({name: 'readme', pass: generateReadme});

--- a/cleanup-passes/tests.ts
+++ b/cleanup-passes/tests.ts
@@ -120,11 +120,4 @@ async function addShadowDomTests(element: ElementRepo): Promise<void> {
   }
 }
 
-register({
-  name: 'add-shadow-dom-tests',
-  pass: addShadowDomTests,
-  // Mark this as true once we've merged all the PRs from this
-  // sheet:
-  // https://docs.google.com/spreadsheets/d/166pE8UwkJQwtUzirEv03kDYQmilKO0-ggZBrrzyDh9g/edit#gid=0
-  runsByDefault: false,
-});
+register({name: 'add-shadow-dom-tests', pass: addShadowDomTests});

--- a/cleanup-passes/travis.ts
+++ b/cleanup-passes/travis.ts
@@ -175,4 +175,4 @@ async function cleanupTravisConfig(element: ElementRepo): Promise<void> {
   }
 }
 
-register({name: 'travis', pass: cleanupTravisConfig, runsByDefault: true});
+register({name: 'travis', pass: cleanupTravisConfig});

--- a/cleanup-passes/typescript.ts
+++ b/cleanup-passes/typescript.ts
@@ -164,8 +164,4 @@ async function typescriptPass(element: ElementRepo): Promise<void> {
   }
 }
 
-register({
-  name: 'typescript',
-  pass: typescriptPass,
-  runsByDefault: false,
-});
+register({name: 'typescript', pass: typescriptPass});

--- a/cleanup-passes/wct-conf.ts
+++ b/cleanup-passes/wct-conf.ts
@@ -67,4 +67,4 @@ async function cleanupWctConf(element: ElementRepo): Promise<void> {
   }
 }
 
-register({name: 'wct-conf', pass: cleanupWctConf, runsByDefault: true});
+register({name: 'wct-conf', pass: cleanupWctConf});

--- a/cleanup.ts
+++ b/cleanup.ts
@@ -29,11 +29,8 @@ import {getPasses, CleanupConfig} from './cleanup-pass';
  * To add a cleanup step, just add it to the array of passes above.
  */
 export async function cleanup(
-    element: ElementRepo, config: CleanupConfig, passesToRun?: string[]) {
+    element: ElementRepo, config: CleanupConfig, passesToRun: string[]) {
   const passes = getPasses().filter(p => {
-    if (passesToRun == null) {
-      return p.runsByDefault;
-    }
     return passesToRun.indexOf(p.name) >= 0;
   });
   for (const step of passes) {


### PR DESCRIPTION
This makes tedium more conservative, and simpler to control.

- Passes and repos must now be specified explicitly. Previously there was a set of automatic passes, and repos were fetched from PolymerElements.
- `--baseBranch` is the branch we will clone from and apply changes to (default "master").
- `--workBranch` is the branch we will commit and push to, and maybe create (default "tedium"). It can be the same as `--baseBranch` if you just want to commit directly, but you'll also have to set `--noPr` in this case or you'll get an error.
- We now create PRs by default instead of magically. The PR will merge `workBranch` into `baseBranch`. Set `--noPr` to not create a PR. Set `--prTitle` to set a custom PR title.
- By default only 1 repo is now pushed unless you ask for more (previously unlimited unless you asked for fewer).